### PR TITLE
Reference forecasts

### DIFF
--- a/climpred_skeleton/alignment.py
+++ b/climpred_skeleton/alignment.py
@@ -23,8 +23,7 @@ class LeadAlignment(TimeManager):
     ):
         super().__init__(initialized, observation)
         self._alignment = alignment
-        self._all_verifs = self._observation['time']
-        self._all_inits = self._initialized['init']
+
         if isinstance(reference, str):
             reference = [reference]
         elif reference is None:

--- a/climpred_skeleton/alignment.py
+++ b/climpred_skeleton/alignment.py
@@ -49,12 +49,12 @@ class LeadAlignment(TimeManager):
 
     def get_alignment(self) -> 'LeadAlignment':
         try:
-            return alignment_dict[self._alignment](
-                self._initialized, self._observation, self._alignment, self._reference
+            return alignment_dict[self.alignment](
+                self.initialized, self.observation, self.alignment, self.reference
             )
         except KeyError:
             raise ValueError(
-                f'{self._alignment} not valid keyword from '
+                f'{self.alignment} not valid keyword from '
                 f'{list(alignment_dict.keys())}'
             )
 
@@ -70,7 +70,7 @@ class LeadAlignment(TimeManager):
                 xr.DataArray(
                     self._shift_hindcast_inits(int(n), freq),
                     dims=['init'],
-                    coords=[self._all_inits],
+                    coords=[self.all_inits],
                 )
                 for n in n
             ],
@@ -81,7 +81,7 @@ class LeadAlignment(TimeManager):
     def _shift_hindcast_inits(self, n: int, freq: str):
         """Helper function to shift the initialized inits by a specific n and freq. Used
         in constructing the init/lead matrix."""
-        time_index = self._all_inits.to_index()
+        time_index = self.all_inits.to_index()
         return time_index.shift(n, freq)
 
 
@@ -102,16 +102,16 @@ class SameInitializations(LeadAlignment):
         # If a persistence forecast is desired, need a union between the
         # initializations and verifs so the same are used.
         if self.score_persistence:
-            union_with_verifs = self._all_inits.isin(self._all_verifs)
+            union_with_verifs = self.all_inits.isin(self.all_verifs)
             init_lead_matrix = init_lead_matrix.where(union_with_verifs, drop=True)
 
-        verifies_at_all_leads = init_lead_matrix.isin(self._all_verifs).all('lead')
+        verifies_at_all_leads = init_lead_matrix.isin(self.all_verifs).all('lead')
         valid_inits = init_lead_matrix['init']
         inits = valid_inits.where(verifies_at_all_leads, drop=True)
-        inits = {lead: inits for lead in self._leads}
+        inits = {lead: inits for lead in self.leads}
         verif_dates = {
             lead: self._shift_cftime_index(inits[lead], 'init', int(n), freq)
-            for (lead, n) in zip(self._leads, n)
+            for (lead, n) in zip(self.leads, n)
         }
         return inits, verif_dates
 

--- a/climpred_skeleton/alignment.py
+++ b/climpred_skeleton/alignment.py
@@ -29,10 +29,23 @@ class LeadAlignment(TimeManager):
         elif reference is None:
             reference = []
         self._reference = reference
+
         if 'persistence' in reference:
-            self._persistence = True
+            self._score_persistence = True
         else:
-            self._persistence = False
+            self._score_persistence = False
+
+    @property
+    def alignment(self):
+        return self._alignment
+
+    @property
+    def reference(self):
+        return self._reference
+
+    @property
+    def score_persistence(self):
+        return self._score_persistence
 
     def get_alignment(self) -> 'LeadAlignment':
         try:
@@ -88,7 +101,7 @@ class SameInitializations(LeadAlignment):
 
         # If a persistence forecast is desired, need a union between the
         # initializations and verifs so the same are used.
-        if self._persistence:
+        if self.score_persistence:
             union_with_verifs = self._all_inits.isin(self._all_verifs)
             init_lead_matrix = init_lead_matrix.where(union_with_verifs, drop=True)
 

--- a/climpred_skeleton/comparison.py
+++ b/climpred_skeleton/comparison.py
@@ -32,7 +32,7 @@ class Comparison(TimeManager):
 
     def get_comparison(self, method) -> 'Comparison':
         try:
-            return comparison_dict[method](self._initialized, self._observation)
+            return comparison_dict[method](self.initialized, self.observation)
         except KeyError:
             raise ValueError(
                 f'{method} not valid keyword from {list(comparison_dict.keys())}'
@@ -58,11 +58,11 @@ class EnsembleToObservation(Comparison):
         self._probabilistic_comparison = False
 
     def broadcast(self) -> Union[xr.Dataset, xr.Dataset]:
-        if 'member' in self._initialized.dims:
-            initialized = self._initialized.mean('member')
+        if 'member' in self.initialized.dims:
+            initialized = self.initialized.mean('member')
         else:
-            initialized = self._initialized
-        return initialized, self._observation
+            initialized = self.initialized
+        return initialized, self.observation
 
 
 class MemberToObservation(Comparison):
@@ -77,9 +77,9 @@ class MemberToObservation(Comparison):
         self._probabilistic_comparison = True
 
     def broadcast(self) -> Union[xr.Dataset, xr.Dataset]:
-        observation = self._observation.expand_dims({'member': self._nmember})
-        observation['member'] = self._members
-        return self._initialized, observation
+        observation = self.observation.expand_dims({'member': self._nmember})
+        observation['member'] = self.members
+        return self.initialized, observation
 
 
 class MemberToControl(Comparison):
@@ -95,8 +95,8 @@ class MemberToControl(Comparison):
 
     def broadcast(self, control_member: list = None) -> Union[xr.Dataset, xr.Dataset]:
         if control_member is None:
-            control_member = self._members[0]
-        observation = self._initialized.isel(member=control_member).squeeze()
+            control_member = self.members[0]
+        observation = self.initialized.isel(member=control_member).squeeze()
         # drop the member being considered as the control.
         initialized = self._drop_members(members=control_member)
         initialized, observation = xr.broadcast(initialized, observation)

--- a/climpred_skeleton/core.py
+++ b/climpred_skeleton/core.py
@@ -35,8 +35,24 @@ class Verification:
         return self._initialized
 
     @property
+    def leads(self):
+        return self._leads
+
+    @property
+    def members(self):
+        return self._members
+
+    @property
+    def nmember(self):
+        return self._nmember
+
+    @property
     def observation(self):
         return self._observation
+
+    @property
+    def units(self):
+        return self._units
 
     def _drop_members(self, members: list = None):
         if members is None:

--- a/climpred_skeleton/core.py
+++ b/climpred_skeleton/core.py
@@ -22,17 +22,21 @@ class Verification:
         self._initialized = initialized.copy()
         self._observation = observation.copy()
 
-        self._leads = self._initialized['lead'].data
-        self._units = self._initialized['lead'].attrs['units']
-        if 'member' in self._initialized.dims:
-            self._nmember = self._initialized['member'].size
-            self._members = self._initialized['member'].data
+        self._leads = self.initialized['lead'].data
+        self._units = self.initialized['lead'].attrs['units']
+        if 'member' in self.initialized.dims:
+            self._nmember = self.initialized['member'].size
+            self._members = self.initialized['member'].data
         else:
             self._nmember, self._members = None, None
 
     @property
     def initialized(self):
         return self._initialized
+
+    @initialized.setter
+    def initialized(self, value):
+        self._initialized = value
 
     @property
     def leads(self):
@@ -50,11 +54,15 @@ class Verification:
     def observation(self):
         return self._observation
 
+    @observation.setter
+    def observation(self, value):
+        self._observation = value
+
     @property
     def units(self):
         return self._units
 
     def _drop_members(self, members: list = None):
         if members is None:
-            members = self._members[0]
-        return self._initialized.drop_sel(member=members)
+            members = self.members[0]
+        return self.initialized.drop_sel(member=members)

--- a/climpred_skeleton/core.py
+++ b/climpred_skeleton/core.py
@@ -30,6 +30,14 @@ class Verification:
         else:
             self._nmember, self._members = None, None
 
+    @property
+    def initialized(self):
+        return self._initialized
+
+    @property
+    def observation(self):
+        return self._observation
+
     def _drop_members(self, members: list = None):
         if members is None:
             members = self._members[0]

--- a/climpred_skeleton/reference.py
+++ b/climpred_skeleton/reference.py
@@ -1,5 +1,0 @@
-from .scoring import Scoring
-
-
-class ReferenceForecast(Scoring):
-    pass

--- a/climpred_skeleton/reference.py
+++ b/climpred_skeleton/reference.py
@@ -1,0 +1,5 @@
+from .scoring import Scoring
+
+
+class ReferenceForecast(Scoring):
+    pass

--- a/climpred_skeleton/scoring.py
+++ b/climpred_skeleton/scoring.py
@@ -68,6 +68,15 @@ class HindcastScoring(Scoring):
         # Just an example metric here.
         return pearson_r(a, b, 'time')
 
+    def _persistence(self, lead):
+        # Use `.where()` instead of `.sel()` to account for resampled inits when
+        # bootstrapping.
+        a = self.observation.where(
+            self.all_verifs.isin(self.scoring_inits[lead]), drop=True
+        )
+        b = self.observation.sel(time=self.scoring_verifs[lead])
+        return a, b
+
     def _skill(self, lead):
         # Use `.where()` instead of `.sel()` to account for resampled inits when
         # bootstrapping.
@@ -76,15 +85,6 @@ class HindcastScoring(Scoring):
             .where(self.all_inits.isin(self.scoring_inits[lead]), drop=True)
             .drop_vars('lead')
             .rename({'init': 'time'})
-        )
-        b = self.observation.sel(time=self.scoring_verifs[lead])
-        return a, b
-
-    def _persistence(self, lead):
-        # Use `.where()` instead of `.sel()` to account for resampled inits when
-        # bootstrapping.
-        a = self.observation.where(
-            self.all_verifs.isin(self.scoring_inits[lead]), drop=True
         )
         b = self.observation.sel(time=self.scoring_verifs[lead])
         return a, b

--- a/climpred_skeleton/scoring.py
+++ b/climpred_skeleton/scoring.py
@@ -25,14 +25,14 @@ class Scoring(TimeManager):
 
 
 class HindcastScoring(Scoring):
-    def __init__(self, initialized, observation, comparison, alignment):
+    def __init__(self, initialized, observation, comparison, alignment, reference=None):
         super().__init__(initialized, observation, comparison)
 
         # Same use of factory pattern. Not sure there's a way to do this in the classes
         # themselves without a recursion nightmare.
         alignment_obj = LeadAlignment(
-            self._initialized, self._observation, alignment
-        ).get_alignment(alignment)
+            self._initialized, self._observation, alignment, reference
+        ).get_alignment()
         inits, verif_dates = alignment_obj._return_inits_and_verifs()
         self._scoring_inits = inits
         self._scoring_verifs = verif_dates

--- a/climpred_skeleton/time.py
+++ b/climpred_skeleton/time.py
@@ -13,6 +13,7 @@ class TimeManager(Verification):
         super().__init__(initialized, observation)
         # Convert `init` and `time` indices to CFTimeIndex.
         self._convert_to_cftime_index()
+        self._units = self._initialized['lead'].attrs['units']
 
         # These occur here to make sure they're in datetime.
         self._all_verifs = self._observation['time']

--- a/climpred_skeleton/time.py
+++ b/climpred_skeleton/time.py
@@ -14,9 +14,18 @@ class TimeManager(Verification):
         # Convert `init` and `time` indices to CFTimeIndex.
         self._convert_to_cftime_index()
         self._units = self._initialized['lead'].attrs['units']
+
         # These occur here to make sure they're in datetime.
         self._all_verifs = self._observation['time']
         self._all_inits = self._initialized['init']
+
+    @property
+    def all_verifs(self):
+        return self._all_verifs
+
+    @property
+    def all_inits(self):
+        return self._all_inits
 
     def _convert_to_cftime_index(self, calendar: str = 'DatetimeProlepticGregorian'):
         """Converts time indices for the prediction and observations to a

--- a/climpred_skeleton/time.py
+++ b/climpred_skeleton/time.py
@@ -30,52 +30,13 @@ class TimeManager(Verification):
     def _convert_to_cftime_index(self, calendar: str = 'DatetimeProlepticGregorian'):
         """Converts time indices for the prediction and observations to a
         CFTimeIndex."""
-
-        def _return_converted_time_index(
-            time_index: Union[
-                xr.CFTimeIndex, pd.DatetimeIndex, pd.Float64Index, pd.Int64Index
-            ]
-        ):
-            assume_annual = False
-
-            if not isinstance(time_index, xr.CFTimeIndex):
-                if isinstance(time_index, pd.DatetimeIndex):
-                    time_strings = [str(t) for t in time_index]
-                    split_dates = [d.split(' ')[0].split('-') for d in time_strings]
-
-                # If Float64Index or Int64Index, assume annual and convert accordingly.
-                elif isinstance(time_index, pd.Float64Index) | isinstance(
-                    time_index, pd.Int64Index
-                ):
-                    warnings.warn(
-                        'Assuming annual resolution due to numeric inits. '
-                        'Change init to a datetime if it is another resolution.'
-                    )
-                    dates = [str(int(t)) + '-01-01' for t in time_index]
-                    split_dates = [d.split('-') for d in dates]
-                    assume_annual = True
-
-                else:
-                    raise ValueError(
-                        'The incoming time index must be pd.Float64Index, '
-                        'pd.Int64Index, xr.CFTimeIndex or '
-                        'pd.DatetimeIndex.'
-                    )
-
-                cftime_dates = [
-                    getattr(cftime, calendar)(int(y), int(m), int(d))
-                    for (y, m, d) in split_dates
-                ]
-                time_index = xr.CFTimeIndex(cftime_dates)
-            return time_index, assume_annual
-
-        self._initialized['init'], assume_annual = _return_converted_time_index(
-            self._initialized['init'].to_index()
+        self._initialized['init'], assume_annual = self._return_converted_time_index(
+            self._initialized['init'].to_index(), calendar
         )
         if assume_annual:
             self._initialized['lead'].attrs['units'] = 'years'
-        self._observation['time'], _ = _return_converted_time_index(
-            self._observation['time'].to_index()
+        self._observation['time'], _ = self._return_converted_time_index(
+            self._observation['time'].to_index(), calendar
         )
 
     def _get_all_lead_cftime_shift_args(self):
@@ -99,6 +60,47 @@ class TimeManager(Verification):
 
         n, freq = d[self._units]
         return n, freq
+
+    @staticmethod
+    def _return_converted_time_index(
+        self,
+        time_index: Union[
+            xr.CFTimeIndex, pd.DatetimeIndex, pd.Float64Index, pd.Int64Index
+        ],
+        calendar: str = 'DatetimeProlepticGregorian',
+    ):
+        assume_annual = False
+
+        if not isinstance(time_index, xr.CFTimeIndex):
+            if isinstance(time_index, pd.DatetimeIndex):
+                time_strings = [str(t) for t in time_index]
+                split_dates = [d.split(' ')[0].split('-') for d in time_strings]
+
+            # If Float64Index or Int64Index, assume annual and convert accordingly.
+            elif isinstance(time_index, pd.Float64Index) | isinstance(
+                time_index, pd.Int64Index
+            ):
+                warnings.warn(
+                    'Assuming annual resolution due to numeric inits. '
+                    'Change init to a datetime if it is another resolution.'
+                )
+                dates = [str(int(t)) + '-01-01' for t in time_index]
+                split_dates = [d.split('-') for d in dates]
+                assume_annual = True
+
+            else:
+                raise ValueError(
+                    'The incoming time index must be pd.Float64Index, '
+                    'pd.Int64Index, xr.CFTimeIndex or '
+                    'pd.DatetimeIndex.'
+                )
+
+            cftime_dates = [
+                getattr(cftime, calendar)(int(y), int(m), int(d))
+                for (y, m, d) in split_dates
+            ]
+            time_index = xr.CFTimeIndex(cftime_dates)
+        return time_index, assume_annual
 
     @staticmethod
     def _shift_cftime_index(

--- a/climpred_skeleton/time.py
+++ b/climpred_skeleton/time.py
@@ -13,7 +13,6 @@ class TimeManager(Verification):
         super().__init__(initialized, observation)
         # Convert `init` and `time` indices to CFTimeIndex.
         self._convert_to_cftime_index()
-        self._units = self._initialized['lead'].attrs['units']
 
         # These occur here to make sure they're in datetime.
         self._all_verifs = self._observation['time']


### PR DESCRIPTION
Getting reference forecasts set up in the scoring pipeline.

**NOTE**: I left off working on getting the control registered as a separate attribute in the PerfectModelScoring so I can then do persistence from there.